### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "okitsu/zabbix-sender",
+    "type": "library",
+    "homepage": "https://github.com/okitsu/php-zabbix-sender",
+    "license": "unknown",
+    "authors": [
+        {"name": "okitsu", "homepage": "http://twitter.com/okt_t"}
+    ],
+    "description": "Zabbix Sender Client implemented in Pure PHP",
+    "keywords": ["zabbix", "monitoring"],
+    "require": {
+        "php": ">=5.3.2"
+    },
+    "autoload": {
+        "psr-0": {"Net\\Zabbix": "src/"}
+    }
+}
+


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a new dependency manager for PHP. It allows you to specify dependencies on a per-project basis. It takes lots of inspiration from NPM and ruby's bundler.

All you need to support composer is a composer.json file. In order to allow easy installation, the repository needs to be added to [packagist](http://packagist.org/), which is the standard repository for composer. Packagist will fetch all the versions from your github repository tags.

Once it has been added, adding php-zabbix-sender to a project will be as easy as creating this composer.json file in the project's directory:

```
{
    "require": {
        "okitsu/zabbix-sender": "*"
    }
}
```

And running this command:

```
$ php composer.phar install
```

Note: Packagist will re-crawl github for new versions all the time. After submitting it once, you don't have to do anything else.

Check out the following information on composer and packagist:
- [getcomposer.org](http://getcomposer.org/)
- [packagist.org](http://packagist.org)
- [composer on GitHub](https://github.com/composer/composer)
- #composer on irc.freenode.net

Cheers!
