### PR TITLE
Along coding standards level psr-0

### DIFF
--- a/examples/sample.php
+++ b/examples/sample.php
@@ -1,27 +1,7 @@
 <?php
-/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 error_reporting(E_ALL | E_STRICT);
-$src = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src';
-set_include_path( get_include_path() . PATH_SEPARATOR . $src);
-
-function my_autoload($className){
-    $src = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src';
-    $replaces = array(
-            '_'  => DIRECTORY_SEPARATOR,
-            '\\' => DIRECTORY_SEPARATOR,
-            '.'  => '', 
-        );
-    $classPath = str_replace(array_keys($replaces),array_values($replaces),$className);
-    $fileName = $src . DIRECTORY_SEPARATOR . $classPath . '.php';
-
-    if(is_readable($fileName)){
-        require_once($fileName);
-    } 
-} 
-
-spl_autoload_register('my_autoload');
-
+require_once __DIR__ . '/vendor/autoload.php'; // using composer.phar
 
 $defined_hostname   = 'localhost';
 $undefined_hostname = 'localhost__';

--- a/src/Net/Zabbix/Agent/Config.php
+++ b/src/Net/Zabbix/Agent/Config.php
@@ -1,21 +1,18 @@
 <?php
-/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 namespace Net\Zabbix\Agent;
 
-if(!defined('ZABBIX_AGENT_DEFAULT_CONFIG_FILE')) {
-    define('ZABBIX_AGENT_DEFAULT_CONFIG_FILE','/etc/zabbix/zabbix_agentd.conf',true);
-}
-
 class Config
 {
-    var $_config_filename = ZABBIX_AGENT_DEFAULT_CONFIG_FILE;
-    var $_config_array = array();
+    /* @var string */
+    private $_config_filename;
+    /* @var array */
+    private $_config_array = array();
      
     function __construct($filename=null){
-        if( isset($filename) and is_readable($filename) ){
-           $this->_config_filename = $filename;
-        }
+        $this->_config_filenme = isset($filename) && is_readable($filename)
+            ? $filename : '/etc/zabbix/zabbix_agentd.conf';
+
         $this->_config_array = $this->_load($this->_config_filename);
     }
     

--- a/src/Net/Zabbix/Exception/SenderNetworkException.php
+++ b/src/Net/Zabbix/Exception/SenderNetworkException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Net\Zabbix\Exception;
+
+class SenderNetworkException extends SenderRuntimeException
+{
+}

--- a/src/Net/Zabbix/Exception/SenderProtocolException.php
+++ b/src/Net/Zabbix/Exception/SenderProtocolException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Net\Zabbix\Exception;
+
+class SenderProtocolException extends SenderRuntimeException
+{
+}

--- a/src/Net/Zabbix/Exception/SenderRuntimeException.php
+++ b/src/Net/Zabbix/Exception/SenderRuntimeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Net\Zabbix\Exception;
+
+class SenderRuntimeException extends \RuntimeException
+{
+}

--- a/tests/Net/Zabbix/SenderTest.php
+++ b/tests/Net/Zabbix/SenderTest.php
@@ -1,5 +1,4 @@
 <?php
-/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 class Zabbix_SenderTest extends \PHPUnit_Framework_TestCase
 {
@@ -39,7 +38,7 @@ class Zabbix_SenderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Net\Zabbix\SenderNetworkException
+     * @expectedException Net\Zabbix\Exception\SenderNetworkException
      */
     public function test_send_fail_invalid_hostname()
     {
@@ -49,7 +48,7 @@ class Zabbix_SenderTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * @expectedException Net\Zabbix\SenderNetworkException
+     * @expectedException Net\Zabbix\Exception\SenderNetworkException
      */
     public function test_send_fail_invalid_port()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,4 @@
 <?php
-/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 error_reporting(E_ALL | E_STRICT);
 $src = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src';


### PR DESCRIPTION
Composer's autoloader is along [psr-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md).

If this repo declare to be available using composer,  it's a desirable one class per file.

Accordingly, want to delete needless define() , cause it's a role of __construct(). (but only this case)

(btw why are you specify case_insensitive option true?)
