### PR TITLE
[Bug] Fix pack() format

### DIFF
--- a/src/Net/Zabbix/Sender.php
+++ b/src/Net/Zabbix/Sender.php
@@ -111,20 +111,14 @@ class Sender {
                                     ) 
                                 );
         $json_length = strlen($json_data);
-        $data_header = pack("aaaaCCCCCCCCC",
+        $data_header = pack("aaaaCV2",
                                 substr($this->_protocolHeaderString,0,1),
                                 substr($this->_protocolHeaderString,1,1),
                                 substr($this->_protocolHeaderString,2,1),
                                 substr($this->_protocolHeaderString,3,1),
                                 intval($this->_protocolVersion),
-                                ($json_length & 0xFF),
-                                ($json_length & 0x00FF)>>8,
-                                ($json_length & 0x0000FF)>>16,
-                                ($json_length & 0x000000FF)>>24,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00
+                                $json_length,
+                                ($json_length >> 32)
                             );
         return ($data_header . $json_data);
     }


### PR DESCRIPTION
When we send large JSON data to discovery rules, script fail with below messages.
This message has been included in json_parser.c of Zabbix source.

```
received invalid JSON object from 127.0.0.1: cannot parse as a valid JSON object: unexpected end of string data

or

received invalid JSON object from 127.0.0.1: cannot parse as a valid JSON object: invalid escape sequence in string at: '\'
```

Test code is below.
Thanks.

``` php
<?php
error_reporting(E_ALL | E_STRICT);
require_once __DIR__ . '/php-zabbix-sender/vendor/autoload.php';
$agentConfig = new \Net\Zabbix\Agent\Config;
$sender = new \Net\Zabbix\Sender();
$sender->importAgentConfig($agentConfig);

// small data
$data_1['data'][] = array(
'{#TESTMACRO1}' => 'hoge1',
'{#TESTMACRO2}' => 'hoge2',
'{#TESTMACRO3}' => 'hoge3'
);

// large data
for ($count = 1; $count <= 200; $count++) {
    $data_2['data'][] = array(
        '{#SCHEMAVERSION}' => $count,
        '{#ORG}' => $count,
        '{#COURSE}' => $count,
        '{#RUN}' => $count
    );
}

// This will success(sometime fail)
$result = $sender
            ->addData('test001', 'discovery001.key', json_encode($data_1))
            ->send();

// This will fail
$result = $sender
            ->addData('test001', 'discovery001.key', json_encode($data_2))
            ->send();

?>
```

![2016-06-29 4 43 37](https://cloud.githubusercontent.com/assets/11495867/16430092/d8d35970-3db4-11e6-8ee7-51e2d8b7896a.png)

![2016-06-29 4 46 38](https://cloud.githubusercontent.com/assets/11495867/16430097/dd800266-3db4-11e6-93ce-494feff49474.png)
